### PR TITLE
Improvement: sendUnlock() on EVM chains must not wait txns' confirmations

### DIFF
--- a/src/providers/evm.provider.adapter.ts
+++ b/src/providers/evm.provider.adapter.ts
@@ -14,7 +14,7 @@ export class EvmAdapterProvider implements ProviderAdapter {
     const tx = data as { data: string; to: string; value: number };
     const gasLimit = await this.connection.eth.estimateGas(tx);
     let gasPrice = await this.connection.eth.getGasPrice();
-    const transactionHash = new Promise((resolve, reject) => {
+    const transactionHash = await new Promise((resolve, reject) => {
       this.connection.eth.sendTransaction({
         ...tx,
         from: this.connection.eth.defaultAccount!,


### PR DESCRIPTION
This PR relaxes order unlocking: instead of waiting for `sendUnlock()` txn being including to the block, it waits only for node accept the transaction for further broadcast, which is enough because in case txn is being lost, it can be generated again (funds are still safu).